### PR TITLE
Hide button "Show All/Less" if guidelines less or equal to 10

### DIFF
--- a/src/components/Guidelines/GuidelineList/GuidelineList.tsx
+++ b/src/components/Guidelines/GuidelineList/GuidelineList.tsx
@@ -21,11 +21,11 @@ export const GuidelineList = ({ guidelines }: { guidelines: Guideline[] }) => {
         {guidelinesToShow.map((guideline) => (
           <GuidelineCard key={guideline.id} guideline={guideline} />
         ))}
-        <div className={styles.showAll}>
+        { guidelines.length <= 10 ? <></> : <div className={styles.showAll}>
           <Button theme="solid" onClick={() => setShowAll(!showAll)}>
             {showAll ? "Show less" : "Show all"}
           </Button>
-        </div>
+        </div> }
       </div>
     </>
   );


### PR DESCRIPTION
We add an empty element instead if the guidelines are less or equal to 10 in amount when searching or filtering